### PR TITLE
Update Web UI continer cmd

### DIFF
--- a/compose-files/web_ui.yml
+++ b/compose-files/web_ui.yml
@@ -5,7 +5,7 @@ services:
     image: dappforce/subsocial-ui:$WEBUI_VERSION
     container_name: $CONT_WEBUI
     restart: on-failure
-    command: bash -c "yarn build && yarn start-prod"
+    command: bash -c "yarn build && yarn start"
     environment:
       - SUBSTRATE_URL=$SUBSTRATE_URL
       - OFFCHAIN_URL=$OFFCHAIN_URL


### PR DESCRIPTION
In newest update of Web UI `start-prod` is replaced with simply `start`