### PR TITLE
Fix web proxying

### DIFF
--- a/compose-files/apps.yml
+++ b/compose-files/apps.yml
@@ -7,8 +7,6 @@ services:
     restart: on-failure
     environment:
       - SUBSTRATE_URL=$SUBSTRATE_URL
-    ports:
-      - "3002:80"
     networks:
       backend:
         ipv4_address: 172.15.0.6

--- a/compose-files/substrate_node.yml
+++ b/compose-files/substrate_node.yml
@@ -11,7 +11,7 @@ services:
       --ws-external
       --telemetry-url ws://telemetry.polkadot.io:1024
       --validator
-      --pruning 'archive'
+      --pruning archive
     volumes:
       - $VOLUME_LOCATION/chain_data/alice:/data
     ports:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -11,6 +11,6 @@ server {
 
 	location /bc/ {
 		rewrite ^/bc(.*) /$1 break;
-		proxy_pass http://172.15.0.6:3002;
+		proxy_pass http://172.15.0.6;
 	}
 }


### PR DESCRIPTION
Now Web-UI and Apps don't expose their ports. NGINX proxy exposes port 80 and redirects to the Docker containers.