### PR TITLE
Make starter compatible with Substrate v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd dappforce-subsocial-starter
 ./start.sh 
 ```
 
-### Launch Substrate-v2 based Subsocial
+### Launch Subsocial based on Substrate v2
 
 First of all, you have to clone a starter repo:
 ```bash
@@ -43,16 +43,16 @@ cd dappforce-subsocial-starter
 ```
 
 There are two ways of starting Subsocial.
-If you want to test locally, then go with:
+If you want to play with Subsocial and launch it as an independent node that is not accessible from outside and not connected to the [official](http://subsocial.network) Subsocial network:
 ```bash
 ./start.sh --tag df-v2
 ```
-If you want to launch your own global Subsocial network:
+If you want to launch your own Subsocial network that is accessible from outside, yet independent and not connected to the [official](http://subsocial.network) Subsocial network:
 ```bash
 ./start.sh --tag df-v2 --global
 ```
 
-If you want to disable some parts of Subsocial, run offchain (i.e) only, specify custom URLs, etc., then you can use flags below.
+If you want to launch only some parts of Subsocial (e.g. offchain only) or specify custom URLs of other parts, then you can use flags listed in the section [Options](#options).
 
 ### Possible issues on Linux
 
@@ -91,7 +91,7 @@ The [start.sh](start.sh) script comes with a set of options for customizing proj
 
 ### Proxy
 
-By default it will start one nginx container with automatically configured proxy. If it is running, you can open the **Web UI** or **Blockchain Exporer** .
+By default it will start one Nginx container with automatically configured proxy. If it is running, you can open the **Web UI** or **Blockchain Explorer** .
 
 | Container name     | External Port | Local URL        | Description   |
 | ------------------ | ------------- | ---------------- | ------------- |
@@ -144,7 +144,7 @@ This one can be managed with `--no-substrate` and `--only-substrate` flags.
 | Container name          | External Port   | Local URL             | Description                  |
 | ----------------------- | --------------- | --------------------- | ---------------------------- |
 | `subsocial-node-alice`  | `9944`          | ws://localhost:9944   | Archive Node
-| `subsocial-node-bob`    |                 |                       | Authority Substrate Node
+| `subsocial-node-bob`    |                 |                       | Authority Node
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ cd dappforce-subsocial-starter
 ./start.sh 
 ```
 
+### Launch Substrate-v2 based Subsocial
+
+First of all, you have to clone a starter repo:
+```bash
+git clone git@github.com:dappforce/dappforce-subsocial-starter.git
+cd dappforce-subsocial-starter 
+```
+
+There are two ways of starting Subsocial.
+If you want to test locally, then go with:
+```bash
+./start.sh --tag df-v2
+```
+If you want to launch your own global Subsocial network:
+```bash
+./start.sh --tag df-v2 --global
+```
+
+If you want to disable some parts of Subsocial, run offchain (i.e) only, specify custom URLs, etc., then you can use flags below.
+
 ### Possible issues on Linux
 
 If you are using Linux and having permission issues with Docker, then you may want to do this:
@@ -69,6 +89,14 @@ The [start.sh](start.sh) script comes with a set of options for customizing proj
 | `--webui-ip`             | Specify Web UI ip address. Example: `./start.sh --global --substrate-url http://172.15.0.2`
 | `--apps-url`             | Specify JS Apps URL. Example: `./start.sh --global --apps-url http://172.15.0.6:3002`
 
+### Proxy
+
+By default it will start one nginx container with automatically configured proxy. If it is running, you can open the **Web UI** or **Blockchain Exporer** .
+
+| Container name     | External Port | Local URL        | Description   |
+| ------------------ | ------------- | ---------------- | ------------- |
+| `subsocial-proxy`  | `80`          |
+
 ### Web UI
 
 By default it will start one container for Web UI. If it is running, you can open the **Subsocial** in your browser:
@@ -79,19 +107,19 @@ This one can be managed with `--no-webui` and `--only-webui` flags.
 
 | Container name     | External Port | Local URL        | Description   |
 | ------------------ | ------------- | ---------------- | ------------- |
-| `subsocial-web-ui` | `80`          | http://localhost | [Subsocial UI](https://github.com/dappforce/dappforce-subsocial-ui)
+| `subsocial-web-ui` |               | http://localhost | [Subsocial UI](https://github.com/dappforce/dappforce-subsocial-ui)
 
 ### Blockchain Explorer (aka JS Apps)
 
 By default it will start one container for JS Apps. If it is running, you can successfully go to the 'Advanced' tab in the Web UI side-menu:
 
-[http://localhost:3002/](http://localhost:3002)
+[http://localhost/bc](http://localhost/bc)
 
 This one can be managed with `--no-apps` and `--only-apps` flags.
 
 | Container name     | External Port | Local URL             | Description     |
 | ------------------ | ------------- | --------------------- | --------------- |
-| `subsocial-apps` | `3002`          | http://localhost:3002 | [Subsocial Apps](https://github.com/dappforce/dappforce-subsocial-apps)
+| `subsocial-apps`   |               | http://localhost/bc   | [Subsocial Apps](https://github.com/dappforce/dappforce-subsocial-apps)
 
 ### Off-chain Storage
 
@@ -104,6 +132,7 @@ This one can be managed with `--no-offchain` and `--only-offchain` flags.
 | `subsocial-offchain`      | `3001`          | http://localhost:3001/v1 | [Subsocial Offchain](https://github.com/dappforce/dappforce-subsocial-offchain)
 | `subsocial-elasticsearch` | `9200`          | http://localhost:9200    | [Elasticsearch](https://www.elastic.co/what-is/elasticsearch)
 | `subsocial-postgres`      |                 |                          | [PostgreSQL](https://www.postgresql.org/about/)
+| `subsocial-ipfs`          | `8080`          |                          | [IPFS](https://github.com/ipfs/go-ipfs/blob/master/README.md)
 
 ### Substrate Node
 
@@ -114,8 +143,8 @@ This one can be managed with `--no-substrate` and `--only-substrate` flags.
 
 | Container name          | External Port   | Local URL             | Description                  |
 | ----------------------- | --------------- | --------------------- | ---------------------------- |
-| `subsocial-node-alice`  | `9944`          | http://localhost:9944 |
-| `subsocial-node-bob`    |                 |                       | Local chain of Substrate Node
+| `subsocial-node-alice`  | `9944`          | ws://localhost:9944   | Archive Node
+| `subsocial-node-bob`    |                 |                       | Authority Substrate Node
 
 
 ## License

--- a/compose-files/offchain.yml
+++ b/compose-files/offchain.yml
@@ -39,23 +39,36 @@ services:
       backend:
         ipv4_address: 172.15.0.5
 
+  ipfs:
+    image: ipfs/go-ipfs:$IPFS_VERSION
+    container_name: $CONT_IPFS
+    restart: on-failure
+    volumes:
+      - $VOLUME_LOCATION/ipfs/staging:/export
+      - $VOLUME_LOCATION/ipfs/data:/data/ipfs
+    ports:
+      - "8080:8080"
+    networks:
+      backend:
+        ipv4_address: 172.15.0.8
+
   offchain:
     image: dappforce/subsocial-offchain:$OFFCHAIN_VERSION
     container_name: $CONT_OFFCHAIN
     depends_on:
       - postgres
       - elasticsearch
+      - ipfs
     restart: on-failure
     environment:
       - NODE_ENV=production
       - SUBSTRATE_URL=$SUBSTRATE_URL
       - PGHOST=172.15.0.4
       - ES_NODE_URL=$ELASTIC_URL
-    volumes:
-      - $VOLUME_LOCATION/ipfs_data:/data
+      - IPFS_URL=$IPFS_URL
     ports:
       - "3001:3001"
-      - "127.0.0.1:5002:5002"
+      - "3011:3011"
     networks:
       backend:
         ipv4_address: 172.15.0.3

--- a/compose-files/substrate_node.yml
+++ b/compose-files/substrate_node.yml
@@ -14,7 +14,6 @@ services:
       --rpc-cors all
       --ws-external
       --rpc-external
-      --telemetry-url ws://telemetry.polkadot.io:1024
       --pruning archive
     volumes:
       - $VOLUME_LOCATION/chain_data/alice:/data
@@ -40,9 +39,11 @@ services:
       --port 30334
       --ws-port 9945
       --rpc-port 9934
-      --telemetry-url ws://telemetry.polkadot.io:1024
     volumes:
       - $VOLUME_LOCATION/chain_data/bob:/data
+    ports:
+      - "9934:9934"
+      - "30334:30334"
     networks:
       backend:
         ipv4_address: 172.15.0.22

--- a/compose-files/substrate_node.yml
+++ b/compose-files/substrate_node.yml
@@ -6,16 +6,22 @@ services:
     restart: on-failure
     command: ./subsocial-node
       -d /data
-      --chain=local
+      --chain df
       --alice
+      --port 30333
+      --ws-port 9944
+      --rpc-port 9933
+      --rpc-cors all
       --ws-external
+      --rpc-external
       --telemetry-url ws://telemetry.polkadot.io:1024
-      --validator
       --pruning archive
     volumes:
       - $VOLUME_LOCATION/chain_data/alice:/data
     ports:
       - "9944:9944"
+      - "9933:9933"
+      - "30333:30333"
     networks:
       backend:
         ipv4_address: 172.15.0.21
@@ -23,17 +29,19 @@ services:
   node_bob:
     image: dappforce/subsocial-node:$NODE_VERSION
     container_name: $CONT_NODE_BOB
+    depends_on:
+      - node_alice
     restart: on-failure
     command: ./subsocial-node
       -d /data
-      --chain=local
+      --chain df
       --bob
-      --port 30344
-      --ws-port 9945
-      --rpc-port 9935
-      --telemetry-url ws://telemetry.polkadot.io:1024
       --validator
-      --bootnodes '/ip4/172.15.0.21/tcp/30333/p2p/QmZ7cDTT4DAesod6gSqUup14dEfhHMyMcuhmfdzBAjqSCF'
+      --port 30334
+      --ws-port 9945
+      --rpc-port 9934
+      --telemetry-url ws://telemetry.polkadot.io:1024
+      --bootnodes '/ip4/172.15.0.21/tcp/30333/p2p/Qme5aPxwEB4xK2ohz3wex8x6XihMmJp487MqFtuEh9XdcE'
     volumes:
       - $VOLUME_LOCATION/chain_data/bob:/data
     networks:

--- a/compose-files/substrate_node.yml
+++ b/compose-files/substrate_node.yml
@@ -41,7 +41,6 @@ services:
       --ws-port 9945
       --rpc-port 9934
       --telemetry-url ws://telemetry.polkadot.io:1024
-      --bootnodes '/ip4/172.15.0.21/tcp/30333/p2p/Qme5aPxwEB4xK2ohz3wex8x6XihMmJp487MqFtuEh9XdcE'
     volumes:
       - $VOLUME_LOCATION/chain_data/bob:/data
     networks:

--- a/compose-files/web_ui.yml
+++ b/compose-files/web_ui.yml
@@ -10,6 +10,7 @@ services:
       - OFFCHAIN_URL=$OFFCHAIN_URL
       - ELASTIC_URL=$ELASTIC_URL
       - APPS_URL=$APPS_URL
+      - IPFS_URL=$IPFS_READONLY_URL
     networks:
       backend:
         ipv4_address: 172.15.0.2

--- a/start.sh
+++ b/start.sh
@@ -282,7 +282,7 @@ while :; do
                 if [[ $COMPOSE_FILES =~ 'offchain' ]] ; then
 
                     # Elasticsearch
-                    printf "\nHold on, starting Offchain:\nSetting up Elasticsearch...\n"
+                    printf "\nHold on, starting Offchain:\nSetting up ElasticSearch...\n"
                     docker container stop ${CONT_OFFCHAIN} > /dev/null
                     until curl -s ${ELASTIC_URL} > /dev/null ; do
                         sleep 2

--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,7 @@ set -e
 
 pushd . > /dev/null
 
-# The following lines ensure we run from the root
+# The following lines ensure we run from the root folder of this Starter
 DIR=`git rev-parse --show-toplevel`
 COMPOSE_DIR="${DIR}/compose-files"
 

--- a/start.sh
+++ b/start.sh
@@ -293,7 +293,7 @@ while :; do
                     docker exec ${CONT_IPFS} \
                         ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["*"]'
                     docker exec ${CONT_IPFS} \
-                        ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "GET", "POST"]'
+                        ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["GET", "POST", "PUT"]'
                     docker restart ${CONT_IPFS} > /dev/null
 
                     # Offchain itself


### PR DESCRIPTION
- Add external IPFS (in separate container)
- Change exported ports in offchain
- Now Substrate nodes will start specific 'Subsocial Testnet' network
- Add readonly IPFS_URL on Web-UI and internal IPFS_URL on Offchain
- Fix bugs/errors, change offchain startup in bash script.