### PR TITLE
Expose IPFS swarm port for IPFS cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ You can specify initial IPFS cluster bootnodes in order to connect to Subsocial 
 ./start.sh --only-ipfs --cluster-bootstrap '"/ip4/172.15.0.9/tcp/9096/p2p/12D3KooWRRyJpS847KJQCEXqWC3AFjaweTBtVvA8DmLz9RxA7yQW","/ip4/174.100.4.101/tcp/9096/p2p/12D3KooWGsddM5p5M2HMF6egoR28mCwnKg75UE6K29BMvzux3WdY"'
 ```
 
-**NOTE:** An argument to `--cluster-bootstrap` should be provided as a single string with URIs wrapped by double quotes each and all are listed separated by commas.
+**NOTE:** `--cluster-bootstrap` value should be provided as a single string with URIs wrapped in double-quotes (`"`) each and separated by commas.
 
 If you want to add, remove or entirely override trusted peers (ones that are able to pin/unpin content on IPFS), you might want to use `--cluster-peers` option:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To learn more about Subsocial, please visit us at [Subsocial.Network](http://sub
 
 Subsocial is the recipient of a technical grant from Web3 Foundation -
 [official announcement](https://medium.com/web3foundation/web3-foundation-grants-wave-3-recipients-6426e77f1230).
-We have successfully delivered on all three milestones submitted in our grant application. 
+We have successfully delivered on all three milestones submitted in our grant application.
 
 ## Requirements
 
@@ -47,7 +47,7 @@ If you're new to Subsocial, it is best to start with the defaults.
 
 ```
 git clone https://github.com/dappforce/dappforce-subsocial-starter.git
-cd dappforce-subsocial-starter 
+cd dappforce-subsocial-starter
 ```
 
 ### Start entire Subsocial project locally
@@ -202,7 +202,7 @@ To get *Peer URI* (e.g `/ip4/172.15.0.9/tcp/9096/p2p/12D3KooWD8YVcSx6ERnEDXZpXzJ
 
 ## Advanced
 
-### Available options 
+### Available options
 
 The [start.sh](start.sh) script comes with a set of options for customizing project startup.
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ We use `--only-ipfs` to run IPFS only:
 You can specify initial IPFS cluster bootnodes in order to connect to Subsocial as a cluster peer. Example:
 
 ```
-./start.sh --only-ipfs --cluster-bootstrap "/ip4/172.15.0.9/tcp/9096/p2p/12D3KooWRRyJpS847KJQCEXqWC3AFjaweTBtVvA8DmLz9RxA7yQW"
+./start.sh --only-ipfs --cluster-bootstrap '"/ip4/172.15.0.9/tcp/9096/p2p/12D3KooWRRyJpS847KJQCEXqWC3AFjaweTBtVvA8DmLz9RxA7yQW"'
 ```
+
+**NOTE:** all Peer URIs should be wrapped by double quotes and listed with comma.
 
 If you want to add, remove or entirely override trusted peers (ones that are able to pin/unpin content on IPFS), you might want to use `--cluster-peers` option:
 

--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ We use `--only-ipfs` to run IPFS only:
 You can specify initial IPFS cluster bootnodes in order to connect to Subsocial as a cluster peer. Example:
 
 ```
-./start.sh --only-ipfs --cluster-bootstrap '"/ip4/172.15.0.9/tcp/9096/p2p/12D3KooWRRyJpS847KJQCEXqWC3AFjaweTBtVvA8DmLz9RxA7yQW"'
+./start.sh --only-ipfs --cluster-bootstrap '"/ip4/172.15.0.9/tcp/9096/p2p/12D3KooWRRyJpS847KJQCEXqWC3AFjaweTBtVvA8DmLz9RxA7yQW","/ip4/174.100.4.101/tcp/9096/p2p/12D3KooWGsddM5p5M2HMF6egoR28mCwnKg75UE6K29BMvzux3WdY"'
 ```
 
-**NOTE:** all Peer URIs should be wrapped by double quotes and listed with comma.
+**NOTE:** An argument to `--cluster-bootstrap` should be provided as a single string with URIs wrapped by double quotes each and all are listed separated by commas.
 
 If you want to add, remove or entirely override trusted peers (ones that are able to pin/unpin content on IPFS), you might want to use `--cluster-peers` option:
 

--- a/compose-files/elasticsearch.yml
+++ b/compose-files/elasticsearch.yml
@@ -5,7 +5,7 @@ services:
     container_name: $CONT_ELASTICSEARCH
     restart: on-failure
     environment:
-      ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+      ES_JAVA_OPTS: "-Xms512m -Xmx1g"
       MAX_MAP_COUNT: "64000"
       bootstrap.memory_lock: "true"
       discovery.type: "single-node"

--- a/compose-files/ipfs.yml
+++ b/compose-files/ipfs.yml
@@ -15,11 +15,6 @@ services:
     networks:
       backend:
         ipv4_address: $IPFS_NODE_IP
-    healthcheck:
-      test: curl -s ${IPFS_READ_ONLY_NODE_URL}/version
-      interval: 5s
-      timeout: 5s
-      retries: 3
 
   ipfs-cluster:
     image: ipfs/ipfs-cluster:$IPFS_CLUSTER_VERSION

--- a/compose-files/ipfs.yml
+++ b/compose-files/ipfs.yml
@@ -11,9 +11,15 @@ services:
     ports:
       - "8080:8080"
       - "5001:5001"
+      - "4001:4001"
     networks:
       backend:
         ipv4_address: $IPFS_NODE_IP
+    healthcheck:
+      test: curl -s ${IPFS_READ_ONLY_NODE_URL}/version
+      interval: 5s
+      timeout: 5s
+      retries: 3
 
   ipfs-cluster:
     image: ipfs/ipfs-cluster:$IPFS_CLUSTER_VERSION

--- a/start.sh
+++ b/start.sh
@@ -531,7 +531,6 @@ while :; do
                 break
             fi
 
-            CLUSTER_CONFIG_PATH=$CLUSTER_CONFIG_FOLDER/service.json
             if [[ ! -f $CLUSTER_CONFIG_PATH ]]; then
                 printf $COLOR_R'ERROR: IPFS Cluster is not yet started.\n' >&2
                 prtinf '>> Start IPFS Cluster to create config JSON\n'$COLOR_RESET >&2

--- a/start.sh
+++ b/start.sh
@@ -149,7 +149,7 @@ stop_container() {
     local cont_name=""
 
     [[ -z $1 ]] || [[ ! -z $2 ]] \
-        && printf $COLOR_R"FATAL: 'stop' command must be provided with 1 argument" \
+        && printf $COLOR_R"FATAL: 'stop' command must be provided with one argument" \
         && exit -1
 
     [[ $1 == offchain ]] && [[ $COMPOSE_FILES =~ 'offchain' ]] \
@@ -164,14 +164,14 @@ stop_container() {
     fi
 }
 
-# Starts container if all conditions are true:
+# Starts a container if the next conditions are met:
 # - Corresponding service exists in $COMPOSE_FILES set
 # - Container is paused at the moment
 start_container(){
     local cont_name
 
     [[ -z $1 ]] || [[ ! -z $2 ]] \
-        && printf $COLOR_R"FATAL: 'stop' command must be provided with 1 argument" && exit -1
+        && printf $COLOR_R"FATAL: 'stop' command must be provided with one argument" && exit -1
 
     [[ $1 == offchain ]] && [[ $COMPOSE_FILES =~ 'offchain' ]] \
         && cont_name=${CONT_OFFCHAIN}


### PR DESCRIPTION
- Fix minimal memory allocated for elasticsearch
- Fix code style. Use `[[` in bash to feel more safe
- Make changes in IPFS Cluster peer store by changing `config.json` with the `jq`, not the `peerstore` file.